### PR TITLE
[Feat] jwt 인증 및 swagger 인증 통합

### DIFF
--- a/src/main/java/com/altong/altong_backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/altong/altong_backend/global/config/SwaggerConfig.java
@@ -1,19 +1,50 @@
 package com.altong.altong_backend.global.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Altong API",
+        version = "v1.0.0",
+        description = "알통 통합 로그인/회원가입 API 명세서"
+    ),
+    security = {
+        @SecurityRequirement(name = "bearerAuth")
+    }
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
+
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI altongOpenAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Altong API")
-                        .description("알통 통합 로그인/회원가입 API 명세서")
-                        .version("v1.0.0"));
+            .components(new Components()
+                .addSecuritySchemes(
+                    "bearerAuth",
+                    new io.swagger.v3.oas.models.security.SecurityScheme()
+                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                )
+            )
+            // 전역 SecurityRequirement(모델 클래스)도 풀네임으로
+            .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearerAuth"))
+            .info(new io.swagger.v3.oas.models.info.Info()
+                .title("Altong API")
+                .version("v1.0.0")
+                .description("알통 로그인/회원가입 및 인증 테스트용 Swagger 문서"));
     }
 }

--- a/src/main/java/com/altong/altong_backend/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/altong/altong_backend/global/jwt/JwtAuthFilter.java
@@ -29,14 +29,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 // 토큰 검증 + 인증 객체 생성 + 시큐리티 컨텍스트 등록
                 Authentication authentication = provider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (ExpiredJwtException e) {
-                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
             } catch (JwtException e) {
                 res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             } catch (Exception e) {
-                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 return;
             }
         }

--- a/src/main/java/com/altong/altong_backend/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/altong/altong_backend/global/jwt/JwtTokenProvider.java
@@ -73,8 +73,7 @@ public class JwtTokenProvider {
         String subject = claims.getSubject();
         String role = claims.get("role", String.class);
 
-        List<SimpleGrantedAuthority> authorities =
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
         return new UsernamePasswordAuthenticationToken(subject, null, authorities);
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ✅ 작업 내용
- JwtAuthFilter: 토큰 파싱 후 SecurityContextHolder에 Authentication 등록 로직 추가
- JwtTokenProvider: getAuthentication() 로직 추가
- SwaggerConfig: JWT Bearer 인증 추가 및 Swagger 인증 테스트 성공

## 📌 관련 이슈
closed #15
