### PR TITLE
[Feat] login user fix & add /api/auth/me

### DIFF
--- a/src/main/java/com/altong/altong_backend/auth/controller/AuthController.java
+++ b/src/main/java/com/altong/altong_backend/auth/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.altong.altong_backend.auth.controller;
 
 import com.altong.altong_backend.auth.dto.request.SignupRequest;
 import com.altong.altong_backend.auth.dto.response.SignupResponse;
+import com.altong.altong_backend.auth.dto.response.UserInfoResponse;
 import com.altong.altong_backend.auth.service.AuthService;
 import com.altong.altong_backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -29,5 +31,11 @@ public class AuthController {
         String refreshToken = body.get("refreshToken");
         String newAccess = authService.refreshAccessToken(refreshToken);
         return ApiResponse.success(Map.of("accessToken", newAccess));
+    }
+
+    // 현재 로그인 유저 정보 조회
+    @GetMapping("/me")
+    public ApiResponse<UserInfoResponse> getMyInfo(Authentication auth) {
+        return ApiResponse.success(authService.getCurrentUserInfo(auth));
     }
 }

--- a/src/main/java/com/altong/altong_backend/auth/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/altong/altong_backend/auth/dto/response/UserInfoResponse.java
@@ -1,0 +1,19 @@
+package com.altong.altong_backend.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+
+    @Schema(description = "유저 이름", example = "altong_user")
+    private String username;
+
+    @Schema(description = "상호명", example = "알통치킨 평택점")
+    private String storeName;
+
+    @Schema(description = "역할", example = "OWNER or EMPLOYEE")
+    private String role;
+}

--- a/src/main/java/com/altong/altong_backend/employee/dto/response/EmployeeLoginResponse.java
+++ b/src/main/java/com/altong/altong_backend/employee/dto/response/EmployeeLoginResponse.java
@@ -2,10 +2,15 @@ package com.altong.altong_backend.employee.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Builder;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class EmployeeLoginResponse {
     private String accessToken;
     private String refreshToken;
+
+    private String username;
+    private String storeName;
 }

--- a/src/main/java/com/altong/altong_backend/employee/service/EmployeeAuthService.java
+++ b/src/main/java/com/altong/altong_backend/employee/service/EmployeeAuthService.java
@@ -44,7 +44,14 @@ public class EmployeeAuthService {
                 .build();
         refreshRepo.save(token);
 
-        return new EmployeeLoginResponse(at, rt);
+        String storeName = emp.getStore() != null ? emp.getStore().getName() : null;
+
+        return EmployeeLoginResponse.builder()
+            .accessToken(at)
+            .refreshToken(rt)
+            .username(emp.getUsername())
+            .storeName(storeName)
+            .build();
     }
 
     /** 로그아웃 */

--- a/src/main/java/com/altong/altong_backend/owner/dto/response/OwnerLoginResponse.java
+++ b/src/main/java/com/altong/altong_backend/owner/dto/response/OwnerLoginResponse.java
@@ -2,10 +2,15 @@ package com.altong.altong_backend.owner.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Builder;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class OwnerLoginResponse {
     private String accessToken;
     private String refreshToken;
+
+    private String username;
+    private String storeName;
 }

--- a/src/main/java/com/altong/altong_backend/owner/service/OwnerAuthService.java
+++ b/src/main/java/com/altong/altong_backend/owner/service/OwnerAuthService.java
@@ -48,7 +48,17 @@ public class OwnerAuthService {
                 .build();
         refreshRepo.save(token);
 
-        return new OwnerLoginResponse(at, rt);
+        // 로그인 응답에 username, storeName 포함
+        String storeName = storeRepo.findByOwner(owner)
+            .map(Store::getName)
+            .orElse(null);
+
+        return OwnerLoginResponse.builder()
+            .accessToken(at)
+            .refreshToken(rt)
+            .username(owner.getUsername())
+            .storeName(storeName)
+            .build();
     }
 
     /** 비밀번호 변경 */


### PR DESCRIPTION
# 🔥*Pull requests*

## ✅ 작업 내용
- 로그인 응답에 `name`, `storeName` 필드 추가
- 로그인 후 헤더 표시용 유저 정보 조회 API (`GET /api/auth/me`) 추가
- Owner/Employee 통합 처리
- Swagger 명세 업데이트

## 📌 관련 이슈
closed #29